### PR TITLE
fixed codeql

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -66,7 +66,7 @@ jobs:
       run: |
         dotnet nuget add source "https://nuget.pkg.github.com/SamSmithNZ-dotcom/index.json" --name "githubfeed" --username "samsmithnz@gmail.com" --password "${{ secrets.PackagesReadPAT_Token }}" --store-password-in-clear-text
         #dotnet restore SamSmithNZ/SamSmithNZ.Service/SamSmithNZ.Service.csproj
-        dotnet build SamSmithNZ/SamSmithNZ.Service/SamSmithNZ.Service.csproj --configuration Debug /p:UseSharedCompilation=false
+        dotnet build src/SamSmithNZ.Service/SamSmithNZ.Service.csproj --configuration Debug /p:UseSharedCompilation=false
 
 
     # ℹ️ Command-line programs to run using the OS shell.


### PR DESCRIPTION
This pull request includes a single change that modifies the path of the project to be built in the `dotnet build` command in the `codeql-analysis.yml` file.

Main interface changes:

* <a href="diffhunk://#diff-63bd641104d10e25f141d518a16b22a151d125e12701df2f9e79734b23b90188L69-R69">`.github/workflows/codeql-analysis.yml`</a>: Changed the path of the project to be built in the `dotnet build` command.