### PR TITLE
Updated packages

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -54,11 +54,11 @@ jobs:
         fetch-depth: 0 #fetch-depth is needed for GitVersion   
     #Install and calculate the new version with GitVersion  
     - name: Install GitVersion
-      uses: gittools/actions/gitversion/setup@v0.10.2
+      uses: gittools/actions/gitversion/setup@v0.12.0
       with:
         versionSpec: 5.x
     - name: Determine Version
-      uses: gittools/actions/gitversion/execute@v0.10.2
+      uses: gittools/actions/gitversion/execute@v0.12.0
       id: gitversion # step id used as reference for output values
     - name: Display GitVersion outputs
       run: |

--- a/src/SamSmithNZ.FFLSetlistScraper.WinForms/SamSmithNZ.FFLSetlistScraper.WinForms.csproj
+++ b/src/SamSmithNZ.FFLSetlistScraper.WinForms/SamSmithNZ.FFLSetlistScraper.WinForms.csproj
@@ -17,7 +17,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="HtmlAgilityPack" Version="1.11.58" />
+    <PackageReference Include="HtmlAgilityPack" Version="1.11.59" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/SamSmithNZ.FunctionalTests/SamSmithNZ.FunctionalTests.csproj
+++ b/src/SamSmithNZ.FunctionalTests/SamSmithNZ.FunctionalTests.csproj
@@ -27,15 +27,15 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.2.0" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.2.0" />
-    <PackageReference Include="coverlet.collector" Version="6.0.0">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.2.2" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.2.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Selenium.Chrome.WebDriver" Version="85.0.0" />
-    <PackageReference Include="Selenium.WebDriver" Version="4.17.0" />
+    <PackageReference Include="Selenium.WebDriver" Version="4.18.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/SamSmithNZ.Service/SamSmithNZ.Service.csproj
+++ b/src/SamSmithNZ.Service/SamSmithNZ.Service.csproj
@@ -13,11 +13,11 @@
 
   <ItemGroup>
     <PackageReference Include="Dapper" Version="2.1.28" />
-    <PackageReference Include="MandMCounter.Core" Version="3.3.7" />
+    <PackageReference Include="MandMCounter.Core" Version="3.3.12" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.22.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="8.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="StackExchange.Redis" Version="2.7.17" />
+    <PackageReference Include="StackExchange.Redis" Version="2.7.27" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
     <PackageReference Include="Swashbuckle.AspNetCore.Swagger" Version="6.5.0" />
     <PackageReference Include="System.Data.SqlClient" Version="4.8.6" />

--- a/src/SamSmithNZ.Tests/SamSmithNZ.Tests.csproj
+++ b/src/SamSmithNZ.Tests/SamSmithNZ.Tests.csproj
@@ -27,16 +27,16 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="coverlet.msbuild" Version="6.0.0">
+		<PackageReference Include="coverlet.msbuild" Version="6.0.1">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="Microsoft.AspNetCore.TestHost" Version="8.0.1" />
+		<PackageReference Include="Microsoft.AspNetCore.TestHost" Version="8.0.2" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="8.0.0" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-		<PackageReference Include="MSTest.TestAdapter" Version="3.2.0" />
-		<PackageReference Include="MSTest.TestFramework" Version="3.2.0" />
-		<PackageReference Include="coverlet.collector" Version="6.0.0">
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+		<PackageReference Include="MSTest.TestAdapter" Version="3.2.2" />
+		<PackageReference Include="MSTest.TestFramework" Version="3.2.2" />
+		<PackageReference Include="coverlet.collector" Version="6.0.1">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>

--- a/src/SamSmithNZ.Web/SamSmithNZ.Web.csproj
+++ b/src/SamSmithNZ.Web/SamSmithNZ.Web.csproj
@@ -26,7 +26,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.22.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="8.0.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="8.0.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/SamSmithNZ.WorldCupGoals.WPF/SamSmithNZ.WorldCupGoals.WPF.csproj
+++ b/src/SamSmithNZ.WorldCupGoals.WPF/SamSmithNZ.WorldCupGoals.WPF.csproj
@@ -23,7 +23,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="HtmlAgilityPack" Version="1.11.58" />
+    <PackageReference Include="HtmlAgilityPack" Version="1.11.59" />
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="8.0.0" />
   </ItemGroup>
 


### PR DESCRIPTION
This pull request primarily includes updates to various dependencies across multiple projects. The most significant changes are the updates to `gittools/actions/gitversion/setup` and `gittools/actions/gitversion/execute` in the `.github/workflows/dotnet.yml` file, and updates to package versions in several `.csproj` files.

Here are the top five most important changes:

* [`.github/workflows/dotnet.yml`](diffhunk://#diff-d5a2cea578a0446aad66faf31bf1076ae94c9916b1a3374e342272a6300e8344L57-R61): Updated the `gittools/actions/gitversion/setup` and `gittools/actions/gitversion/execute` actions to version `v0.12.0` from `v0.10.2`. This change will affect the version calculation process in the CI/CD pipeline.

Updates to Package Versions:

* [`src/SamSmithNZ.FFLSetlistScraper.WinForms/SamSmithNZ.FFLSetlistScraper.WinForms.csproj`](diffhunk://#diff-c09f42462d4cd4cd731fd8065dd475670376a4291afdec09528341146591ab82L20-R20): Updated the `HtmlAgilityPack` package to version `1.11.59` from `1.11.58`.
* [`src/SamSmithNZ.FunctionalTests/SamSmithNZ.FunctionalTests.csproj`](diffhunk://#diff-d0d37e749ffe4b1ebf8aa70a0629fbc636497e3ddfee61e5cefa75ae82fa5476L30-R38): Updated several packages, including `Microsoft.NET.Test.Sdk`, `MSTest.TestAdapter`, `MSTest.TestFramework`, `coverlet.collector`, and `Selenium.WebDriver` to newer versions.
* [`src/SamSmithNZ.Service/SamSmithNZ.Service.csproj`](diffhunk://#diff-53fd9bc95cd5cf0ce2cb10615b2b8f5c004488534adc26e2fe90dd7067d3c8e1L16-R20): Updated the `MandMCounter.Core` and `StackExchange.Redis` packages to newer versions.
* [`src/SamSmithNZ.Tests/SamSmithNZ.Tests.csproj`](diffhunk://#diff-9b47966ec81fb495f5bf9d1bf11fc8421daaf05c585fc81e690611d5ef1d4e12L30-R39): Updated several packages, including `coverlet.msbuild`, `Microsoft.AspNetCore.TestHost`, `Microsoft.NET.Test.Sdk`, `MSTest.TestAdapter`, `MSTest.TestFramework`, and `coverlet.collector` to newer versions.