### PR TITLE
Package updates

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -155,7 +155,7 @@ jobs:
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         path-to-lcov: src/SamSmithNZ.Tests/TestResults/coverage.info  
-    - uses: samsmithnz/DotNetTestResults@0.1.5 
+    - uses: samsmithnz/DotNetTestResults@0.1.9 
       if: false
       with:
         fileName: ${{ github.workspace }}/TestOutput.xml

--- a/src/SamSmithNZ.FunctionalTests/SamSmithNZ.FunctionalTests.csproj
+++ b/src/SamSmithNZ.FunctionalTests/SamSmithNZ.FunctionalTests.csproj
@@ -30,7 +30,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="3.2.2" />
     <PackageReference Include="MSTest.TestFramework" Version="3.2.2" />
-    <PackageReference Include="coverlet.collector" Version="6.0.1">
+    <PackageReference Include="coverlet.collector" Version="6.0.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/SamSmithNZ.Service/SamSmithNZ.Service.csproj
+++ b/src/SamSmithNZ.Service/SamSmithNZ.Service.csproj
@@ -12,12 +12,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Dapper" Version="2.1.28" />
+    <PackageReference Include="Dapper" Version="2.1.35" />
     <PackageReference Include="MandMCounter.Core" Version="3.3.12" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.22.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="8.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="StackExchange.Redis" Version="2.7.27" />
+    <PackageReference Include="StackExchange.Redis" Version="2.7.33" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
     <PackageReference Include="Swashbuckle.AspNetCore.Swagger" Version="6.5.0" />
     <PackageReference Include="System.Data.SqlClient" Version="4.8.6" />

--- a/src/SamSmithNZ.Tests/SamSmithNZ.Tests.csproj
+++ b/src/SamSmithNZ.Tests/SamSmithNZ.Tests.csproj
@@ -27,16 +27,16 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="coverlet.msbuild" Version="6.0.1">
+		<PackageReference Include="coverlet.msbuild" Version="6.0.2">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="Microsoft.AspNetCore.TestHost" Version="8.0.2" />
+		<PackageReference Include="Microsoft.AspNetCore.TestHost" Version="8.0.3" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="8.0.0" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
 		<PackageReference Include="MSTest.TestAdapter" Version="3.2.2" />
 		<PackageReference Include="MSTest.TestFramework" Version="3.2.2" />
-		<PackageReference Include="coverlet.collector" Version="6.0.1">
+		<PackageReference Include="coverlet.collector" Version="6.0.2">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>

--- a/src/SamSmithNZ.Web/SamSmithNZ.Web.csproj
+++ b/src/SamSmithNZ.Web/SamSmithNZ.Web.csproj
@@ -26,7 +26,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.22.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="8.0.2" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="8.0.3" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This pull request primarily involves updates to various package versions across multiple project files. The changes include updating the version of `samsmithnz/DotNetTestResults` used in the GitHub workflow, as well as upgrading several package versions in the `.csproj` files of the `SamSmithNZ.FunctionalTests`, `SamSmithNZ.Service`, `SamSmithNZ.Tests`, and `SamSmithNZ.Web` projects.

Version updates:

* [`.github/workflows/dotnet.yml`](diffhunk://#diff-d5a2cea578a0446aad66faf31bf1076ae94c9916b1a3374e342272a6300e8344L158-R158): Updated the version of `samsmithnz/DotNetTestResults` used in the GitHub workflow from `0.1.5` to `0.1.9`.
* [`src/SamSmithNZ.FunctionalTests/SamSmithNZ.FunctionalTests.csproj`](diffhunk://#diff-d0d37e749ffe4b1ebf8aa70a0629fbc636497e3ddfee61e5cefa75ae82fa5476L33-R33): Updated the version of `coverlet.collector` from `6.0.1` to `6.0.2`.
* [`src/SamSmithNZ.Service/SamSmithNZ.Service.csproj`](diffhunk://#diff-53fd9bc95cd5cf0ce2cb10615b2b8f5c004488534adc26e2fe90dd7067d3c8e1L15-R20): Updated the versions of `Dapper` from `2.1.28` to `2.1.35` and `StackExchange.Redis` from `2.7.27` to `2.7.33`.
* [`src/SamSmithNZ.Tests/SamSmithNZ.Tests.csproj`](diffhunk://#diff-9b47966ec81fb495f5bf9d1bf11fc8421daaf05c585fc81e690611d5ef1d4e12L30-R39): Updated the versions of `coverlet.msbuild` from `6.0.1` to `6.0.2` and `Microsoft.AspNetCore.TestHost` from `8.0.2` to `8.0.3`.
* [`src/SamSmithNZ.Web/SamSmithNZ.Web.csproj`](diffhunk://#diff-e49aed7755212f1e86781085e5e71af6d62caa0733f4b71b42e221560dc83c54L29-R29): Updated the version of `Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation` from `8.0.2` to `8.0.3`.