### PR TITLE
Update packages

### DIFF
--- a/src/SamSmithNZ.FFLSetlistScraper.WinForms/SamSmithNZ.FFLSetlistScraper.WinForms.csproj
+++ b/src/SamSmithNZ.FFLSetlistScraper.WinForms/SamSmithNZ.FFLSetlistScraper.WinForms.csproj
@@ -17,7 +17,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="HtmlAgilityPack" Version="1.11.59" />
+    <PackageReference Include="HtmlAgilityPack" Version="1.11.61" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/SamSmithNZ.FunctionalTests/SamSmithNZ.FunctionalTests.csproj
+++ b/src/SamSmithNZ.FunctionalTests/SamSmithNZ.FunctionalTests.csproj
@@ -28,14 +28,14 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.2.2" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.2.2" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.3.1" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.3.1" />
     <PackageReference Include="coverlet.collector" Version="6.0.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Selenium.Chrome.WebDriver" Version="85.0.0" />
-    <PackageReference Include="Selenium.WebDriver" Version="4.18.1" />
+    <PackageReference Include="Selenium.WebDriver" Version="4.20.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/SamSmithNZ.Tests/SamSmithNZ.Tests.csproj
+++ b/src/SamSmithNZ.Tests/SamSmithNZ.Tests.csproj
@@ -31,11 +31,11 @@
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="Microsoft.AspNetCore.TestHost" Version="8.0.3" />
+		<PackageReference Include="Microsoft.AspNetCore.TestHost" Version="8.0.4" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="8.0.0" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
-		<PackageReference Include="MSTest.TestAdapter" Version="3.2.2" />
-		<PackageReference Include="MSTest.TestFramework" Version="3.2.2" />
+		<PackageReference Include="MSTest.TestAdapter" Version="3.3.1" />
+		<PackageReference Include="MSTest.TestFramework" Version="3.3.1" />
 		<PackageReference Include="coverlet.collector" Version="6.0.2">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/SamSmithNZ.Web/SamSmithNZ.Web.csproj
+++ b/src/SamSmithNZ.Web/SamSmithNZ.Web.csproj
@@ -26,7 +26,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.22.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="8.0.3" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="8.0.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/SamSmithNZ.WorldCupGoals.WPF/SamSmithNZ.WorldCupGoals.WPF.csproj
+++ b/src/SamSmithNZ.WorldCupGoals.WPF/SamSmithNZ.WorldCupGoals.WPF.csproj
@@ -23,7 +23,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="HtmlAgilityPack" Version="1.11.59" />
+    <PackageReference Include="HtmlAgilityPack" Version="1.11.61" />
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="8.0.0" />
   </ItemGroup>
 


### PR DESCRIPTION
This pull request primarily includes updates to the versions of various packages used across multiple projects in the solution. The most significant changes include updates to the `HtmlAgilityPack`, `MSTest.TestAdapter`, `MSTest.TestFramework`, `Microsoft.AspNetCore.TestHost`, `Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation`, and `Selenium.WebDriver` packages.

Package updates:

* [`src/SamSmithNZ.FFLSetlistScraper.WinForms/SamSmithNZ.FFLSetlistScraper.WinForms.csproj`](diffhunk://#diff-c09f42462d4cd4cd731fd8065dd475670376a4291afdec09528341146591ab82L20-R20): Updated `HtmlAgilityPack` from version `1.11.59` to `1.11.61`.
* [`src/SamSmithNZ.FunctionalTests/SamSmithNZ.FunctionalTests.csproj`](diffhunk://#diff-d0d37e749ffe4b1ebf8aa70a0629fbc636497e3ddfee61e5cefa75ae82fa5476L31-R38): Updated `MSTest.TestAdapter` and `MSTest.TestFramework` from version `3.2.2` to `3.3.1`, and `Selenium.WebDriver` from version `4.18.1` to `4.20.0`.
* [`src/SamSmithNZ.Tests/SamSmithNZ.Tests.csproj`](diffhunk://#diff-9b47966ec81fb495f5bf9d1bf11fc8421daaf05c585fc81e690611d5ef1d4e12L34-R38): Updated `Microsoft.AspNetCore.TestHost` from version `8.0.3` to `8.0.4`, and `MSTest.TestAdapter` and `MSTest.TestFramework` from version `3.2.2` to `3.3.1`.
* [`src/SamSmithNZ.Web/SamSmithNZ.Web.csproj`](diffhunk://#diff-e49aed7755212f1e86781085e5e71af6d62caa0733f4b71b42e221560dc83c54L29-R29): Updated `Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation` from version `8.0.3` to `8.0.4`.
* [`src/SamSmithNZ.WorldCupGoals.WPF/SamSmithNZ.WorldCupGoals.WPF.csproj`](diffhunk://#diff-85ad574a777257545baa850066f9c9ea295f1c062f39ff1151ff48aeca2a7556L26-R26): Updated `HtmlAgilityPack` from version `1.11.59` to `1.11.61`.