### PR TITLE
updated player migration

### DIFF
--- a/src/SamSmithNZ.WorldCupGoals.WPF/SamSmithNZ.WorldCupGoals.WPF.csproj
+++ b/src/SamSmithNZ.WorldCupGoals.WPF/SamSmithNZ.WorldCupGoals.WPF.csproj
@@ -21,7 +21,9 @@
     <Content Include="appsettings.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
-    <Content Include="Soccer.ico" />
+    <Content Include="Soccer.ico">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/SamSmithNZ.WorldCupGoals.WPF/TeamSquadsMigration.xaml.cs
+++ b/src/SamSmithNZ.WorldCupGoals.WPF/TeamSquadsMigration.xaml.cs
@@ -36,7 +36,7 @@ namespace SamSmithNZ.WorldCupGoals.WPF
             TeamDataAccess daTeam = new(_configuration);
             List<Team> teams = await daTeam.GetList();
 
-            string url = "https://en.wikipedia.org/wiki/2022_FIFA_World_Cup%27_Cup_squads";
+            string url = "https://en.wikipedia.org/wiki/UEFA_Euro_2024_squads";
             lblURL.Content = url; 
             HtmlWeb web = new();
             HtmlDocument doc = web.Load(url);


### PR DESCRIPTION
This pull request primarily focuses on two changes in the `SamSmithNZ.WorldCupGoals.WPF` project. The first change is in the project file itself, where the `Soccer.ico` file has been updated to always copy to the output directory when the project is built. The second change is in the `TeamSquadsMigration.xaml.cs` file, where the URL used to fetch squad data has been updated to point to the UEFA Euro 2024 squads instead of the 2022 FIFA World Cup squads.