### PR TITLE
Updating odds to work with tournament and add draws

### DIFF
--- a/src/SamSmithNZ.Service/Controllers/WorldCup/GameController.cs
+++ b/src/SamSmithNZ.Service/Controllers/WorldCup/GameController.cs
@@ -23,6 +23,12 @@ namespace SamSmithNZ.Service.Controllers.WorldCup
             return await _repo.GetList(tournamentCode, roundNumber, roundCode, includeGoals);
         }
 
+        [HttpGet("GetGamesByTournament")]
+        public async Task<List<Game>> GetGamesByTournament(int tournamentCode)
+        {
+            return await _repo.GetListByTournament(tournamentCode);
+        }
+
         [HttpGet("GetGamesByTeam")]
         public async Task<List<Game>> GetGamesByTeam(int teamCode)
         {

--- a/src/SamSmithNZ.Service/Controllers/WorldCup/TournamentOddsController.cs
+++ b/src/SamSmithNZ.Service/Controllers/WorldCup/TournamentOddsController.cs
@@ -1,0 +1,12 @@
+﻿using Microsoft.AspNetCore.Mvc;
+
+namespace SamSmithNZ.Service.Controllers.WorldCup
+{
+    public class TournamentOddsController : Controller
+    {
+        public IActionResult Index()
+        {
+            return View();
+        }
+    }
+}

--- a/src/SamSmithNZ.Service/Models/WorldCup/Game.cs
+++ b/src/SamSmithNZ.Service/Models/WorldCup/Game.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using SamSmithNZ.Service.Models.GuitarTab;
+using System;
 
 namespace SamSmithNZ.Service.Models.WorldCup
 {
@@ -102,15 +103,17 @@ namespace SamSmithNZ.Service.Models.WorldCup
         {
             get
             {
-                if (this.Team1PreGameEloRating == null || this.Team2PreGameEloRating == null)
+                if (this.Team1PreGameEloRating != null && this.Team2PreGameEloRating != null)
                 {
-                    return -1;
+                    if (_team1ChanceToWin == -1 || _team2ChanceToWin == -1)
+                    {
+                        CalculateOdds();
+                    }
+                    return _team1ChanceToWin;
                 }
                 else
                 {
-                    //team_a_win_prob = 1.0/(10.0^((team_b - team_a)/400.0) + 1.0)
-                    double result = 1.0 / (Math.Pow(10, (((double)this.Team2PreGameEloRating - (double)this.Team1PreGameEloRating) / 400.0)) + 1.0) * 100;
-                    return Math.Round(result,2);
+                    return -1;
                 }
             }
         }
@@ -119,16 +122,79 @@ namespace SamSmithNZ.Service.Models.WorldCup
         {
             get
             {
-                if (this.Team1PreGameEloRating == null || this.Team2PreGameEloRating == null)
+                if (this.Team1PreGameEloRating != null && this.Team2PreGameEloRating != null)
                 {
-                    return -1;
+                    if (_team1ChanceToWin == -1 || _team2ChanceToWin == -1)
+                    {
+                        CalculateOdds();
+                    }
+                    return _team2ChanceToWin;
                 }
                 else
                 {
-                    //team_a_win_prob = 1.0/(10.0^((team_b - team_a)/400.0) + 1.0)
-                    double result = 1.0 / (Math.Pow(10, (((double)this.Team1PreGameEloRating - (double)this.Team2PreGameEloRating) / 400.0)) + 1.0) * 100;
-                    return Math.Round(result, 2);
+                    return -1;
                 }
+                //if (this.Team1PreGameEloRating == null || this.Team2PreGameEloRating == null)
+                //{
+                //    return -1;
+                //}
+                //else
+                //{
+                //    //team_a_win_prob = 1.0/(10.0^((team_b - team_a)/400.0) + 1.0)
+                //    double result = 1.0 / (Math.Pow(10, (((double)this.Team1PreGameEloRating - (double)this.Team2PreGameEloRating) / 400.0)) + 1.0) * 100;
+                //    return Math.Round(result, 2);
+                //}
+            }
+        }
+
+        public double TeamChanceToDraw
+        {
+            get
+            {
+                if (this.Team1PreGameEloRating != null && this.Team2PreGameEloRating != null)
+                {
+                    if (_team1ChanceToWin == -1 || _team2ChanceToWin == -1)
+                    {
+                        CalculateOdds();
+                    }
+                    return _teamChanceToDraw;
+                }
+                else
+                {
+                    return -1;
+                }
+            }
+        }
+
+        private double _team1ChanceToWin = -1;
+        private double _team2ChanceToWin = -1;
+        private double _teamChanceToDraw = -1;
+        private void CalculateOdds()
+        {
+            if (this.Team1PreGameEloRating == null || this.Team2PreGameEloRating == null)
+            {
+                _team1ChanceToWin = -1;
+                _team2ChanceToWin = -1;
+                _teamChanceToDraw = -1;
+            }
+            else
+            {
+                //team_a_win_prob = 1.0/(10.0^((team_b - team_a)/400.0) + 1.0)
+                double team1Result = 1.0 / (1 + Math.Pow(10, (((double)this.Team2PreGameEloRating - (double)this.Team1PreGameEloRating) / 400.0))) * 100;
+                //_team1ChanceToWin= Math.Round(team1Result, 2);
+
+                //team_a_win_prob = 1.0/(10.0^((team_b - team_a)/400.0) + 1.0)
+                double team2Result = 1.0 / (1 + Math.Pow(10, (((double)this.Team1PreGameEloRating - (double)this.Team2PreGameEloRating) / 400.0))) * 100;
+                //_team2ChanceToWin= Math.Round(team2Result, 2);
+
+                double k = 0.2;
+                double drawResult = k / (1 + Math.Pow(10, Math.Abs((double)this.Team1PreGameEloRating - (double)this.Team2PreGameEloRating) / 400.0)) * 100;
+                //_teamChanceToDraw = Math.Round(drawResult, 2);
+
+                //Normalize the results
+                _team1ChanceToWin = Math.Round(team1Result / (team1Result + team2Result + drawResult) * 100, 2);
+                _team2ChanceToWin = Math.Round(team2Result / (team1Result + team2Result + drawResult) * 100, 2);
+                _teamChanceToDraw = Math.Round(drawResult / (team1Result + team2Result + drawResult) * 100, 2);
             }
         }
 

--- a/src/SamSmithNZ.Service/Utility.cs
+++ b/src/SamSmithNZ.Service/Utility.cs
@@ -1,0 +1,12 @@
+﻿namespace SamSmithNZ.Service
+{
+    public class Utility
+    {
+        private readonly static System.Random rnd = new();
+        public static double GenerateRandomNumber(int lowerBound, int upperBound)
+        {
+            double result = rnd.Next(lowerBound, upperBound + 1) / 100; // +1 because the upperbound is never used
+            return result;
+        }
+    }
+}

--- a/src/SamSmithNZ.Tests/WorldCup/ELORatingTests.cs
+++ b/src/SamSmithNZ.Tests/WorldCup/ELORatingTests.cs
@@ -91,37 +91,37 @@ namespace SamSmithNZ.Tests.WorldCup
             game1.Team1PreGameEloRating = argentina;
             game1.Team2PreGameEloRating = croatia;
             double argentinaChanceToWin1 = game1.Team1ChanceToWin;
-            Assert.AreEqual(63.47, argentinaChanceToWin1);
+            Assert.AreEqual(59.15, argentinaChanceToWin1);
 
             Service.Models.WorldCup.Game game2 = new();
             game2.Team1PreGameEloRating = argentina;
             game2.Team2PreGameEloRating = france;
             double argentinaChanceToWin2 = game2.Team1ChanceToWin;
-            Assert.AreEqual(43.14, argentinaChanceToWin2);
+            Assert.AreEqual(39.71, argentinaChanceToWin2);
 
             Service.Models.WorldCup.Game game3 = new();
             game3.Team1PreGameEloRating = argentina;
             game3.Team2PreGameEloRating = morrocco;
             double argentinaChanceToWin3 = game3.Team1ChanceToWin;
-            Assert.AreEqual(52.73, argentinaChanceToWin3);
+            Assert.AreEqual(48.18, argentinaChanceToWin3);
 
             Service.Models.WorldCup.Game game4 = new();
             game4.Team1PreGameEloRating = france;
             game4.Team2PreGameEloRating = croatia;
             double franceChanceToWin4 = game4.Team1ChanceToWin;
-            Assert.AreEqual(69.61, franceChanceToWin4);
+            Assert.AreEqual(65.62, franceChanceToWin4);
 
             Service.Models.WorldCup.Game game5 = new();
             game5.Team1PreGameEloRating = france;
             game5.Team2PreGameEloRating = morrocco;
             double franceChanceToWin5 = game5.Team1ChanceToWin;
-            Assert.AreEqual(59.52, franceChanceToWin5);
+            Assert.AreEqual(55.07, franceChanceToWin5);
 
             Service.Models.WorldCup.Game game6 = new();
             game6.Team1PreGameEloRating = croatia;
             game6.Team2PreGameEloRating = morrocco;
             double croatiaChanceToWin6 = game6.Team1ChanceToWin;
-            Assert.AreEqual(39.1, croatiaChanceToWin6);
+            Assert.AreEqual(36.26, croatiaChanceToWin6);
 
 
             //SF1 (2 paths)

--- a/src/SamSmithNZ.Tests/WorldCup/GamesUnitTests.cs
+++ b/src/SamSmithNZ.Tests/WorldCup/GamesUnitTests.cs
@@ -172,8 +172,8 @@ namespace SamSmithNZ.Tests.WorldCup
 
             //assert
             Assert.AreEqual(game.Team1ChanceToWin, game.Team2ChanceToWin);
-            Assert.AreEqual(45, game.Team1ChanceToWin);
-            Assert.AreEqual(9, game.TeamChanceToDraw);
+            Assert.AreEqual(45.45, game.Team1ChanceToWin);
+            Assert.AreEqual(9.09, game.TeamChanceToDraw);
         }
 
         [TestMethod]

--- a/src/SamSmithNZ.Tests/WorldCup/GamesUnitTests.cs
+++ b/src/SamSmithNZ.Tests/WorldCup/GamesUnitTests.cs
@@ -172,7 +172,8 @@ namespace SamSmithNZ.Tests.WorldCup
 
             //assert
             Assert.AreEqual(game.Team1ChanceToWin, game.Team2ChanceToWin);
-            Assert.AreEqual(50, game.Team1ChanceToWin);
+            Assert.AreEqual(45, game.Team1ChanceToWin);
+            Assert.AreEqual(9, game.TeamChanceToDraw);
         }
 
         [TestMethod]

--- a/src/SamSmithNZ.Tests/WorldCup/TeamStatisticsTests.cs
+++ b/src/SamSmithNZ.Tests/WorldCup/TeamStatisticsTests.cs
@@ -41,8 +41,9 @@ namespace SamSmithNZ.Tests.WorldCup
                     Assert.AreEqual(1835, game.Team2PreGameEloRating);
                     Assert.AreEqual(2028, game.Team1PostGameEloRating);
                     Assert.AreEqual(1790, game.Team2PostGameEloRating);
-                    Assert.AreEqual(70.10, game.Team1ChanceToWin);
-                    Assert.AreEqual(29.90, game.Team2ChanceToWin);
+                    Assert.AreEqual(66.14, game.Team1ChanceToWin);
+                    Assert.AreEqual(28.21, game.Team2ChanceToWin);
+                    Assert.AreEqual(5.64, game.TeamChanceToDraw);
                 }
 
             }

--- a/src/SamSmithNZ.Tests/WorldCup/TournamentOddsTests.cs
+++ b/src/SamSmithNZ.Tests/WorldCup/TournamentOddsTests.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SamSmithnNZ.Tests;
+using SamSmithNZ.Service.Controllers.WorldCup;
+using SamSmithNZ.Service.DataAccess.WorldCup;
+using SamSmithNZ.Service.Models.WorldCup;
+using System.Threading.Tasks;
+using System.Collections.Generic;
+using SamSmithNZ.Service;
+using System.Diagnostics;
+
+namespace SamSmithNZ.Tests.WorldCup
+{
+    [TestClass]
+    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+    public class TournamentOddsTests : BaseIntegrationTest
+    {
+        [TestMethod()]
+        public async Task TouramentEuro2024OddsTest()
+        {
+            //arrange
+            GameController gameController = new(new GameDataAccess(base.Configuration));
+            int tournamentCode = 317;
+
+            //act
+            List<Game> games = await gameController.GetGamesByTournament(tournamentCode);
+            foreach (Game game in games)
+            {
+                int team1Won = 0;
+                int team2Won = 0;
+                int sampleSize = 10000;
+                double team1ChanceToWin = game.Team1ChanceToWin;
+                double team2ChanceToWin = game.Team2ChanceToWin;
+                Debug.WriteLine(game.Team1Name + " has a " + team1ChanceToWin + "% chance to win against " + game.Team2Name);
+                for (int i = 0; i < sampleSize; i++)
+                {
+                    if (Utility.GenerateRandomNumber(0, 100) < (team1ChanceToWin / 100))
+                    {
+                        team1Won++;
+                    }
+                    else
+                    {
+                        team2Won++;
+                    }
+                }
+                Debug.WriteLine(game.Team1Name + " won " + team1Won + " times, for " + ((double)team1Won / (double)sampleSize).ToString("0.00%") + " of the time against " + game.Team2Name);
+                break;
+            }
+
+        }
+    }
+}


### PR DESCRIPTION
Addition of new methods and controllers:
* [`src/SamSmithNZ.Service/Controllers/WorldCup/GameController.cs`](diffhunk://#diff-ebcfda353d4c86175934f39ae9c56286f4394f1c06f241f3c2adcf890402c8c4R26-R31): Added a new method `GetGamesByTournament` to fetch games by tournament code.
* [`src/SamSmithNZ.Service/Controllers/WorldCup/TournamentOddsController.cs`](diffhunk://#diff-f0cef420889eb4e0147564e3700f4ff52d8992c7f539f974ff7a7b2df5b2ccfcR1-R12): Added a new `TournamentOddsController` with an `Index` method.
* [`src/SamSmithNZ.Service/Utility.cs`](diffhunk://#diff-d3bf324b129585d77052f3007d1a77a28834ce0e60338938a099b36663c85e76R1-R12): Added a new `Utility` class with a method `GenerateRandomNumber` for generating random numbers within a given range.

Updated game prediction logic:
* [`src/SamSmithNZ.Service/Models/WorldCup/Game.cs`](diffhunk://#diff-4566b838c8d8a3400899364e9f6f0a22f7c91c283a44fc5ede19a559671577deL105-R116): The logic for calculating the chances of winning for each team (`Team1ChanceToWin`, `Team2ChanceToWin`) has been updated. A new method `CalculateOdds` has been added to calculate the odds. Also, a new property `TeamChanceToDraw` has been added to calculate the chances of a draw. [[1]](diffhunk://#diff-4566b838c8d8a3400899364e9f6f0a22f7c91c283a44fc5ede19a559671577deL105-R116) [[2]](diffhunk://#diff-4566b838c8d8a3400899364e9f6f0a22f7c91c283a44fc5ede19a559671577deL122-R197)

Updated tests:
* [`src/SamSmithNZ.Tests/WorldCup/ELORatingTests.cs`](diffhunk://#diff-eabddb1f38be696338994dcca31e6b11b4f0536903480b5903f6d3e2b706c059L94-R124): Updated the `SemiFinal2022ELORatingsAndOddsTest` to reflect the changes in the odds calculation logic.
* [`src/SamSmithNZ.Tests/WorldCup/GamesUnitTests.cs`](diffhunk://#diff-dbfa932090a99b05259facb46173ea325647620fa4269f5b35dabd97703db77aL175-R176): Updated the `GamesTeamsAreEqualELONoTeamsTest` to reflect the changes in the odds calculation logic.
* [`src/SamSmithNZ.Tests/WorldCup/TeamStatisticsTests.cs`](diffhunk://#diff-c5fbd2247adbf31b3005da7997305749c72b72e8f4886f67ece4f57777c068feL44-R46): Updated the `GetMatchUpForGameTest` to reflect the changes in the odds calculation logic.
* [`src/SamSmithNZ.Tests/WorldCup/TournamentOddsTests.cs`](diffhunk://#diff-e91b9215c734a61ccbf73c6bf18606416c26e8b6b89720abb60b3d5ca2a5306cR1-R52): Added a new test `TouramentEuro2024OddsTest` to test the new odds calculation logic.