### PR TITLE
Tournament odds9

### DIFF
--- a/src/SamSmithNZ.Database/dbo/Stored Procedures/FB_GetTournamentsImportStatus.sql
+++ b/src/SamSmithNZ.Database/dbo/Stored Procedures/FB_GetTournamentsImportStatus.sql
@@ -14,6 +14,7 @@ BEGIN
 		SUM(g.team_1_normal_time_score) + SUM(ISNULL(g.team_1_extra_time_score,0)) + SUM(g.team_2_normal_time_score) + SUM(ISNULL(g.team_2_extra_time_score,0)) AS TotalGoals,
 		(SELECT COUNT(g5.goal_code) FROM wc_goal g5 JOIN wc_game g6 ON g5.game_code = g6.game_code WHERE g6.tournament_code = t.tournament_code AND g5.is_penalty = 1) AS TotalPenalties,
 		SUM(ISNULL(g.team_1_penalties_score,0)) + SUM(ISNULL(g.team_2_penalties_score,0)) AS TotalShootoutGoals,
+		(SELECT COUNT(g7.goal_code) FROM wc_goal g7 JOIN wc_game g8 ON g7.game_code = g8.game_code WHERE g8.tournament_code = t.tournament_code AND g7.is_own_goal = 1) AS TotalOwnGoals,
 		((tcs.team_percent * 0.25) + (tcs.game_percent * 0.25) + (tcs.player_percent * 0.25) + (tcs.goals_percent * 0.20) + (tcs.penalty_shootout_goals_percent * 0.05)) AS ImportingTotalPercentComplete,
 		tcs.team_percent AS ImportingTeamPercent, 
 		tcs.game_percent AS ImportingGamePercent, 

--- a/src/SamSmithNZ.Service/Models/WorldCup/TournamentImportStatus.cs
+++ b/src/SamSmithNZ.Service/Models/WorldCup/TournamentImportStatus.cs
@@ -12,6 +12,7 @@
         public int TotalGoals { get; set; }
         public int TotalPenalties { get; set; }
         public int TotalShootoutGoals { get; set; }
+        public int TotalOwnGoals { get; set; }
         public decimal ImportingTotalPercentComplete { get; set; }
         public decimal ImportingTeamPercent { get; set; }
         public decimal ImportingGamePercent { get; set; }

--- a/src/SamSmithNZ.Web/Views/WorldCup/Index.cshtml
+++ b/src/SamSmithNZ.Web/Views/WorldCup/Index.cshtml
@@ -25,9 +25,9 @@
                 <th>Round 1</th>
                 <th>Round 2</th>
                 <th>Round 3</th>
-                <th>Goals per game</th>
                 <th>Goals</th>
                 <th>PK Goals</th>
+                <th>Own Goals</th>
                 <th>Games</th>
                 @*<th>% Data Loaded</th>*@
                 <th>Data Missing</th>
@@ -79,19 +79,17 @@
                         }
                     </td>
                     <td>
-                        @if (item.MinGameTime != null && Model.TournamentsImportStatus[i].TotalGamesCompleted > 0)
-                        {
-                            <span>@(((float)Model.TournamentsImportStatus[i].TotalGoals / (float)Model.TournamentsImportStatus[i].TotalGamesCompleted).ToString("0.00"))</span>
-                        }
-                        @if (Model.TournamentsImportStatus[i].TotalGames > Model.TournamentsImportStatus[i].TotalGamesCompleted && Model.TournamentsImportStatus[i].TotalGamesCompleted > 0)
-                        {
-                            <span> (@Model.TournamentsImportStatus[i].TotalGamesCompleted/@Model.TournamentsImportStatus[i].TotalGames games completed)</span>
-                        }
-                    </td>
-                    <td>
                         @if (item.MinGameTime != null)
                         {
-                            <span>@Model.TournamentsImportStatus[i].TotalGoals</span>
+                            <span>@Model.TournamentsImportStatus[i].TotalGoals goals</span><br />
+                            @if (item.MinGameTime != null && Model.TournamentsImportStatus[i].TotalGamesCompleted > 0)
+                            {
+                                <span>@(((float)Model.TournamentsImportStatus[i].TotalGoals / (float)Model.TournamentsImportStatus[i].TotalGamesCompleted).ToString("0.00")) per game</span>
+                            }
+                            @if (Model.TournamentsImportStatus[i].TotalGames > Model.TournamentsImportStatus[i].TotalGamesCompleted && Model.TournamentsImportStatus[i].TotalGamesCompleted > 0)
+                            {
+                                <span> (@Model.TournamentsImportStatus[i].TotalGamesCompleted/@Model.TournamentsImportStatus[i].TotalGames games completed)</span>
+                            }
                         }
                     </td>
                     <td>
@@ -100,6 +98,7 @@
                             <span>@Model.TournamentsImportStatus[i].TotalPenalties</span>
                         }
                     </td>
+                    <td></td>
                     <td>
                         @if (item.MinGameTime != null)
                         {


### PR DESCRIPTION
This pull request primarily focuses on adding tracking for "own goals" in the World Cup application. The changes span across the SQL stored procedure `FB_GetTournamentsImportStatus.sql`, the `TournamentImportStatus` model, and the `Index.cshtml` view. The changes ensure that own goals are now counted and displayed in the application.