### PR TITLE
World cup fix to top32 teams

### DIFF
--- a/src/SamSmithNZ.Database/dbo/Stored Procedures/FB_SavePlayoffDetails.sql
+++ b/src/SamSmithNZ.Database/dbo/Stored Procedures/FB_SavePlayoffDetails.sql
@@ -97,7 +97,7 @@ BEGIN
 		AND te.team_code = @WinningTeamCode
 	END
 	--Move the team to the next round
-	ELSE IF ((@RoundCode = '16' OR @RoundCode = 'QF' OR @RoundCode = 'SF') AND @WinningTeamCode > 0 AND @LosingTeamCode > 0)
+	ELSE IF ((@RoundCode = '32' OR @RoundCode = '16' OR @RoundCode = 'QF' OR @RoundCode = 'SF') AND @WinningTeamCode > 0 AND @LosingTeamCode > 0)
 	BEGIN
 		DECLARE @NewGameNumber INT
 		SELECT @NewGameNumber = game_number

--- a/src/SamSmithNZ.Web/Views/WorldCup/Playoffs32Teams.cshtml
+++ b/src/SamSmithNZ.Web/Views/WorldCup/Playoffs32Teams.cshtml
@@ -130,6 +130,10 @@
             font-weight: bold;
         }
 
+        .PlayoffTeamNameLong {
+            font-size: 9px;
+        }
+
         .BorderBottom {
             border-bottom: darkgray 1px solid;
         }

--- a/src/SamSmithNZ.Web/Views/WorldCup/_PlayoffGamePartial.cshtml
+++ b/src/SamSmithNZ.Web/Views/WorldCup/_PlayoffGamePartial.cshtml
@@ -13,7 +13,7 @@
                 {
                     <img src="~/WorldCup/Teams/@Model.CurrentGame.Team1FlagName" CssClass="flagicon" width="22" bordercolor="DarkGray" borderstyle="Solid" borderwidth="1px" align="top" />
                 }
-                <a href="@Url.Action("Team", "WorldCup" , new { teamCode=@Model.CurrentGame.Team1Code })">@Model.CurrentGame.Team1Name</a> @Model.TeamExtraText
+                <a class="@((Model.CurrentGame.Team1Name?.Length ?? 0) > 15 ? "PlayoffTeamNameLong" : "")" href="@Url.Action("Team", "WorldCup" , new { teamCode=@Model.CurrentGame.Team1Code })">@Model.CurrentGame.Team1Name</a> @Model.TeamExtraText
             </td>
         }
         else
@@ -34,7 +34,7 @@
                 {
                     <img src="~/WorldCup/Teams/@Model.CurrentGame.Team2FlagName" CssClass="flagicon" width="22" bordercolor="DarkGray" borderstyle="Solid" borderwidth="1px" align="top" />
                 }
-                <a href="@Url.Action("Team", "WorldCup" , new { teamCode=@Model.CurrentGame.Team2Code })">@Model.CurrentGame.Team2Name</a> @Model.TeamExtraText
+                <a class="@((Model.CurrentGame.Team2Name?.Length ?? 0) > 15 ? "PlayoffTeamNameLong" : "")" href="@Url.Action("Team", "WorldCup" , new { teamCode=@Model.CurrentGame.Team2Code })">@Model.CurrentGame.Team2Name</a> @Model.TeamExtraText
             </td>
         }
         else


### PR DESCRIPTION
This pull request introduces improvements to the handling and display of playoff teams, especially for tournaments with 32 teams and teams with long names. The changes ensure that the logic for moving teams to the next round supports 32-team playoffs and that long team names are styled appropriately for better readability in the UI.

**Playoff logic update:**

* Updated the stored procedure `FB_SavePlayoffDetails.sql` to include support for 32-team playoffs when moving teams to the next round.

**UI improvements for long team names:**

* Added a new CSS class `.PlayoffTeamNameLong` in `Playoffs32Teams.cshtml` to style long team names with a smaller font size.
* Updated `_PlayoffGamePartial.cshtml` to apply the `.PlayoffTeamNameLong` class to team name links when the name exceeds 15 characters, for both Team 1 and Team 2. [[1]](diffhunk://#diff-47b37051392732ae8e2a0cf08f725bc82161a9f99ae0e5c88d6d0066d55d759bL16-R16) [[2]](diffhunk://#diff-47b37051392732ae8e2a0cf08f725bc82161a9f99ae0e5c88d6d0066d55d759bL37-R37)